### PR TITLE
Support importing extension exports with ext: prefix

### DIFF
--- a/index.js
+++ b/index.js
@@ -78,6 +78,22 @@ module.exports = function(options = {}) {
           return callback(null, 'root flarum.core.compat[\'' + matches[1] + '\']');
         }
         callback();
+      },
+
+      // Support importing extensions
+      function(context, request, callback) {
+        let matches = /^ext:([^\/]+)\/(?:flarum-(?:ext-)?)?([^\/]+)(?:\/(.+))?$/.exec(request);
+
+        if (matches) {
+          const id = `${matches[1]}-${matches[2]}`;
+          const path = [id, ...(matches[3] || '').split('/')]
+            .map(p => `['${p}']`)
+            .join('');
+
+          return callback(null, 'root flarum.extensions' + path)
+        }
+
+        callback();
       }
     ],
 


### PR DESCRIPTION
- Supports `flarum-` & `flarum-ext-` prefixes.
- Works with `require` and `import`

```js
import 'ext:fof/byobu/components/PrivateDiscussionsUserPage';
```

<details>
<summary>RegEx matches demo</summary>


![image](https://user-images.githubusercontent.com/6401250/85225008-237ebd00-b39c-11ea-8e8a-b3be6728fd2d.png)
![image](https://user-images.githubusercontent.com/6401250/85225032-47420300-b39c-11ea-995d-17d417db75c0.png)
![image](https://user-images.githubusercontent.com/6401250/85225027-3f825e80-b39c-11ea-8f04-060609bc65a3.png)

</details>


![image](https://user-images.githubusercontent.com/6401250/85224966-cdaa1500-b39b-11ea-8444-00458a1ffca4.png)
