### PR TITLE
Support including flarum/<namespace> in import

### DIFF
--- a/index.js
+++ b/index.js
@@ -74,8 +74,8 @@ module.exports = function(options = {}) {
       // Support importing old-style core modules.
       function(context, request, callback) {
         let matches;
-        if ((matches = /^flarum\/(.+)$/.exec(request))) {
-          return callback(null, 'root flarum.core.compat[\'' + matches[1] + '\']');
+        if ((matches = /^flarum\/(?:(admin|common|forum)\/)?(.+)$/.exec(request))) {
+          return callback(null, 'root flarum.core.compat[\'' + matches[2] + '\']');
         }
         callback();
       }


### PR DESCRIPTION
This allows extension developers to use Flarum typings (whenever they are available) and include common/, etc... in their import statements so the typings work properly (or at all).

This is not a breaking change. If the extension developer imports from both `flarum/Component` and `flarum/common/Component`, webpack will merge the two import statements (they both evaluate to `flarum.core.compat['Component']`).